### PR TITLE
Install improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+PredictTool/Quadruple Agent
+PredictTool/Replays Folder

--- a/PredictTool/CompileGamestates.py
+++ b/PredictTool/CompileGamestates.py
@@ -199,8 +199,7 @@ def CompileGamestates(directory):
 def CompileGamestatesToDataframe(file):
     gamestateList = []
 
-    filepath = 'Quadruple Agent' + "/" + file
-    valid, timelineList, timelineJSON = GetTimeline(filepath)
+    valid, timelineList, timelineJSON = GetTimeline(file)
     if valid == True:
         guest_list = {}
         hl_count = 0

--- a/PredictTool/GetReplayJSON.py
+++ b/PredictTool/GetReplayJSON.py
@@ -11,7 +11,7 @@ def GetJSON(directory, json_directory):
                         )
     iteration = 1
     for file in list_of_files:
-        filepath = directory + "/" + file
+        filepath = directory / file
         print(file)
         upload_file = open(filepath, 'rb')
         response = requests.post(url, files={'file': upload_file})
@@ -25,7 +25,7 @@ def GetJSON(directory, json_directory):
         timestamp = response_json
         if '/steam' in spy:
             spy = spy[:-6]
-        dumpfile = json_directory + "/" + "game" + str(iteration)
+        dumpfile = json_directory / ("game" + str(iteration))
         with open(dumpfile, 'w') as outfile:
             json.dump(response_json, outfile)
         iteration += 1

--- a/PredictTool/Predict_Tool.py
+++ b/PredictTool/Predict_Tool.py
@@ -1,14 +1,27 @@
-from GetReplayJSON import GetJSON
-from predict_live import PredictLive
+from pathlib import Path
 import os
 
-GetJSON('Replays Folder', 'Quadruple Agent')
+from GetReplayJSON import GetJSON
+from predict_live import PredictLive
 
-list_of_files = filter(lambda x: os.path.isfile(os.path.join('Quadruple Agent', x)),
-                       os.listdir('Quadruple Agent'))
-list_of_files = sorted( list_of_files,
-                        key = lambda x: os.path.getmtime(os.path.join('Quadruple Agent', x))
-                        )
+CODE_FOLDER = Path(__file__).parent
+
+REPLAYS_FOLDER = CODE_FOLDER / 'Replays Folder'
+QUADRUPLE_AGENT_FOLDER = CODE_FOLDER / 'Quadruple Agent'
+
+if not REPLAYS_FOLDER.exists():
+    REPLAYS_FOLDER.mkdir()
+
+if not QUADRUPLE_AGENT_FOLDER.exists():
+    QUADRUPLE_AGENT_FOLDER.mkdir()
+
+GetJSON(REPLAYS_FOLDER, QUADRUPLE_AGENT_FOLDER)
+
+list_of_files = filter(lambda x: os.path.isfile(QUADRUPLE_AGENT_FOLDER / x),
+                       QUADRUPLE_AGENT_FOLDER.iterdir())
+list_of_files = sorted(list_of_files,
+                       key=lambda x: os.path.getmtime(QUADRUPLE_AGENT_FOLDER / x)
+                       )
 for file in list_of_files:
     input()
     print(file)

--- a/PredictTool/Predict_Tool.py
+++ b/PredictTool/Predict_Tool.py
@@ -1,11 +1,6 @@
 from GetReplayJSON import GetJSON
-from predict_live import get_prediction
-from predict_live import encode_missing_variables
 from predict_live import PredictLive
-from CompileGamestates import CompileGamestatesToDataframe
-import sys
 import os
-import time
 
 GetJSON('Replays Folder', 'Quadruple Agent')
 

--- a/PredictTool/Predict_Tool.py
+++ b/PredictTool/Predict_Tool.py
@@ -24,6 +24,6 @@ list_of_files = sorted(list_of_files,
                        )
 for file in list_of_files:
     input()
-    print(file)
+    print(file.name)
     PredictLive(file)
     os.remove(file)

--- a/PredictTool/Predict_Tool.py
+++ b/PredictTool/Predict_Tool.py
@@ -17,14 +17,13 @@ if not QUADRUPLE_AGENT_FOLDER.exists():
 
 GetJSON(REPLAYS_FOLDER, QUADRUPLE_AGENT_FOLDER)
 
-list_of_files = filter(lambda x: os.path.isfile(QUADRUPLE_AGENT_FOLDER / x),
+list_of_files = filter(lambda x: os.path.isfile(x),
                        QUADRUPLE_AGENT_FOLDER.iterdir())
 list_of_files = sorted(list_of_files,
-                       key=lambda x: os.path.getmtime(QUADRUPLE_AGENT_FOLDER / x)
+                       key=lambda x: os.path.getmtime(x)
                        )
 for file in list_of_files:
     input()
     print(file)
     PredictLive(file)
-    filepath = 'Quadruple Agent/' + file
-    os.remove(filepath)
+    os.remove(file)

--- a/PredictTool/predict_live.py
+++ b/PredictTool/predict_live.py
@@ -1,13 +1,14 @@
 from CompileGamestates import CompileGamestatesToDataframe
+from pathlib import Path
 import pickle
-import pandas as pd
-import numpy as np
 from time import time
-import sklearn
+
+CODE_FOLDER = Path(__file__).parent
+
 def get_prediction(gamestate):
-    with open('sp_predict.pkl', 'rb') as pickler:
+    with open(CODE_FOLDER / 'sp_predict.pkl', 'rb') as pickler:
         sp_predict = pickle.load(pickler)
-    with open('predict_scaler.pkl', 'rb') as pickler:
+    with open(CODE_FOLDER / 'predict_scaler.pkl', 'rb') as pickler:
         scaler = pickle.load(pickler)
     gamestate_data = gamestate[["bug_avail", "da_avail", "swap_avail", "inspect_avail", "seduce_avail", "purloin_avail", "fp_avail",
                                             "micro_avail", "guest_count", "reqmissions",


### PR DESCRIPTION
Making install process more seamless for people cloning the repo.

Automatically create Replays Folder and Quadruple Agent folder if they don't exist.
Switch to using pathlib and basing paths of the location of the scripts - this way even if you call the script from a different directory things should work nicely.